### PR TITLE
C28x compatibility

### DIFF
--- a/src/core/co_types.h
+++ b/src/core/co_types.h
@@ -25,6 +25,12 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+// For microcontrollers that do not have uint8_t/int8_t
+#ifdef __TMS320C28XX__
+typedef uint16_t uint8_t;
+typedef int16_t int8_t;
+#endif
+
 /******************************************************************************
 * PUBLIC MACROS
 ******************************************************************************/

--- a/src/object/cia301/co_emcy_hist.c
+++ b/src/object/cia301/co_emcy_hist.c
@@ -199,7 +199,7 @@ void COEmcyHistAdd(CO_EMCY *emcy, uint8_t err, CO_EMCY_USR *usr)
         val |= (((uint32_t)usr->Hist) << 16);
     }
     obj = CODictFind(cod, CO_DEV(COT_OBJECT, sub));
-    (void)uint32->Write(obj, node, &val, sizeof(val));
+    (void)uint32->Write(obj, node, &val, COT_ENTRY_SIZE);
 
     /* update number of stored entries in history */
     emcy->Hist.Num++;
@@ -207,7 +207,7 @@ void COEmcyHistAdd(CO_EMCY *emcy, uint8_t err, CO_EMCY_USR *usr)
         emcy->Hist.Num = emcy->Hist.Max;
     } else {
         obj = CODictFind(cod, CO_DEV(COT_OBJECT, 0));
-        (void)uint8->Write(obj, node, &(emcy->Hist.Num), sizeof(emcy->Hist.Num));
+        (void)uint8->Write(obj, node, &(emcy->Hist.Num), (uint32_t)1u);
     }
 }
 
@@ -239,12 +239,12 @@ void COEmcyHistReset(CO_EMCY *emcy)
         node->Error = CO_ERR_NONE;
         return;
     }
-    (void)uint8->Write(obj, node, &val08, sizeof(val08));
+    (void)uint8->Write(obj, node, &val08, (uint32_t)1u);
 
     /* clear all emergency entries in history */
     for (sub = 1; sub <= emcy->Hist.Max; sub++) {
         obj = CODictFind(cod, CO_DEV(COT_OBJECT, sub));
-        (void)uint32->Write(obj, node, &val32, sizeof(val32));
+        (void)uint32->Write(obj, node, &val32, COT_ENTRY_SIZE);
     }
 
     /* update history state */

--- a/src/object/cia301/co_emcy_id.c
+++ b/src/object/cia301/co_emcy_id.c
@@ -70,14 +70,14 @@ static CO_ERR COTEmcyIdWrite(struct CO_OBJ_T *obj, struct CO_NODE_T *node, void 
     ASSERT_EQU_ERR(size, COT_ENTRY_SIZE, CO_ERR_BAD_ARG);
 
     newId = *(uint32_t*)buffer;
-    (void)uint32->Read(obj, node, &oldId, sizeof(oldId));
+    (void)uint32->Read(obj, node, &oldId, COT_ENTRY_SIZE);
 
     /* when current entry is active, bits 0 to 29 shall not be changed */
     if ((oldId & CO_EMCY_COBID_OFF) == (uint32_t)0) {
         if ((newId & CO_EMCY_COBID_MASK) != (oldId & CO_EMCY_COBID_MASK)) {
             result = CO_ERR_OBJ_RANGE;
         } else {
-            result = uint32->Write(obj, node, &newId, sizeof(newId));
+            result = uint32->Write(obj, node, &newId, COT_ENTRY_SIZE);
         }
     } else {
         /* Conformance Test case : 2.11 - Test name : SDO 11
@@ -87,7 +87,7 @@ static CO_ERR COTEmcyIdWrite(struct CO_OBJ_T *obj, struct CO_NODE_T *node, void 
          * SDO 11: Valid abort codes are 06090030h, 06090032h or 08000000h
          */
         if (newId >= COT_COBID_MIN) {
-            result = uint32->Write(obj, node, &newId, sizeof(newId));
+            result = uint32->Write(obj, node, &newId, COT_ENTRY_SIZE);
         } else {
             result = CO_ERR_OBJ_RANGE;
         }

--- a/src/object/cia301/co_hb_cons.c
+++ b/src/object/cia301/co_hb_cons.c
@@ -133,7 +133,7 @@ static CO_ERR COTNmtHbConsInit(struct CO_OBJ_T *obj, struct CO_NODE_T *node)
     if (CO_GET_IDX(obj->Key) == COT_OBJECT) {
         if (CO_GET_SUB(obj->Key) == 0) {
             /* loop through configured number of consumers */
-            (void)uint8->Read(obj, node, &num, sizeof(num));
+            (void)uint8->Read(obj, node, &num, (uint32_t)1u);
             while (num > 0) {
                 /* check if consumer subindex exists */
                 obj = CODictFind(&node->Dict, CO_DEV(COT_OBJECT, num));

--- a/src/object/cia301/co_hb_prod.c
+++ b/src/object/cia301/co_hb_prod.c
@@ -113,7 +113,7 @@ static CO_ERR COTNmtHbProdWrite(struct CO_OBJ_T *obj, struct CO_NODE_T *node, vo
         }
 
         /* use basic type to update the object entry */
-        result = uint16->Write(obj, node, &cycTime, sizeof(cycTime));
+        result = uint16->Write(obj, node, &cycTime, COT_ENTRY_SIZE);
     }
     return (result);
 }
@@ -145,7 +145,7 @@ static CO_ERR COTNmtHbProdInit(struct CO_OBJ_T *obj, struct CO_NODE_T *node)
         }
 
         /* start heartbeat producer timer with given cycletime */
-        (void)uint16->Read(obj, node, &cycTime, sizeof(cycTime));
+        (void)uint16->Read(obj, node, &cycTime, COT_ENTRY_SIZE);
         if (cycTime > 0) {
             ticks = COTmrGetTicks(tmr, cycTime, CO_TMR_UNIT_1MS);
             nmt->Tmr = COTmrCreate(tmr,

--- a/src/object/cia301/co_pdo_id.c
+++ b/src/object/cia301/co_pdo_id.c
@@ -98,10 +98,10 @@ static CO_ERR COTPdoIdWrite(struct CO_OBJ_T *obj, struct CO_NODE_T *node, void *
         num  = pcomidx & COT_OBJECT_NUM;
     }
 
-    (void)uint32->Read(obj, node, &oid, sizeof(oid));
+    (void)uint32->Read(obj, node, &oid, COT_ENTRY_SIZE);
     if ((oid & CO_TPDO_COBID_OFF) == 0) {
         if ((nid & CO_TPDO_COBID_OFF) != 0) {
-            result = uint32->Write(obj, node, &nid, sizeof(nid));
+            result = uint32->Write(obj, node, &nid, COT_ENTRY_SIZE);
             if (nmt->Mode == CO_OPERATIONAL) {
                 if (tpdo != 0) {
                     COTPdoReset(tpdo, num);
@@ -115,9 +115,9 @@ static CO_ERR COTPdoIdWrite(struct CO_OBJ_T *obj, struct CO_NODE_T *node, void *
         }
     } else {
         if ((nid & CO_TPDO_COBID_OFF) != 0) {
-            result = uint32->Write(obj, node, &nid, sizeof(nid));
+            result = uint32->Write(obj, node, &nid, COT_ENTRY_SIZE);
         } else {
-            result = uint32->Write(obj, node, &nid, sizeof(nid));
+            result = uint32->Write(obj, node, &nid, COT_ENTRY_SIZE);
             if (nmt->Mode == CO_OPERATIONAL) {
                 if (tpdo != 0) {
                     COTPdoReset(tpdo, num);

--- a/src/object/cia301/co_pdo_map.c
+++ b/src/object/cia301/co_pdo_map.c
@@ -121,7 +121,7 @@ static CO_ERR COTPdoMapWrite(struct CO_OBJ_T *obj, struct CO_NODE_T *node, void 
     }
 
     /* ok, write new PDO mapping */
-    result = uint32->Write(obj, node, &map, sizeof(map));
+    result = uint32->Write(obj, node, &map, COT_ENTRY_SIZE);
     return (result);
 }
 

--- a/src/object/cia301/co_pdo_num.c
+++ b/src/object/cia301/co_pdo_num.c
@@ -107,7 +107,7 @@ static CO_ERR COTPdoNumWrite(struct CO_OBJ_T *obj, struct CO_NODE_T *node, void 
     }
 
     /* finaly: store new number of PDO mappings */
-    result = uint8->Write(obj, node, &mapnum, sizeof(mapnum));
+    result = uint8->Write(obj, node, &mapnum, COT_ENTRY_SIZE);
     return (result);
 }
 

--- a/src/object/cia301/co_pdo_type.c
+++ b/src/object/cia301/co_pdo_type.c
@@ -85,7 +85,7 @@ static CO_ERR COTPdoTypeWrite(struct CO_OBJ_T *obj, struct CO_NODE_T *node, void
 
     /* write new PDO type */
     type    = *(uint8_t*)buffer;
-    result = uint8->Write(obj, node, &type, sizeof(type));
+    result = uint8->Write(obj, node, &type, COT_ENTRY_SIZE);
     return (result);
 }
 

--- a/src/object/cia301/co_sdo_id.c
+++ b/src/object/cia301/co_sdo_id.c
@@ -74,12 +74,12 @@ static CO_ERR COTSdoIdWrite(struct CO_OBJ_T *obj, struct CO_NODE_T *node, void *
     ASSERT_EQU_ERR(size, 4u, CO_ERR_BAD_ARG);
 
     newval = *(uint32_t *)buffer;
-    (void)uint32->Read(obj, node, &curval, sizeof(curval));
+    (void)uint32->Read(obj, node, &curval, COT_ENTRY_SIZE);
     num = CO_GET_IDX(obj->Key) & 0x7F;
 
     if ((curval & CO_SDO_ID_OFF) == 0) {
         if ((newval & CO_SDO_ID_OFF) != 0) {
-            err = uint32->Write(obj, node, &newval, sizeof(newval));
+            err = uint32->Write(obj, node, &newval, COT_ENTRY_SIZE);
             if (err == CO_ERR_NONE) {
                 COSdoReset(node->Sdo, num, node);
             }
@@ -87,7 +87,7 @@ static CO_ERR COTSdoIdWrite(struct CO_OBJ_T *obj, struct CO_NODE_T *node, void *
             return (CO_ERR_OBJ_RANGE);
         }
     } else {
-        err = uint32->Write(obj, node, &newval, sizeof(newval));
+        err = uint32->Write(obj, node, &newval, COT_ENTRY_SIZE);
     }
     if (err == CO_ERR_NONE) {
         COSdoEnable(node->Sdo, num);

--- a/src/object/cia301/co_sync_cycle.c
+++ b/src/object/cia301/co_sync_cycle.c
@@ -77,9 +77,9 @@ static CO_ERR COTSyncCycleWrite(struct CO_OBJ_T *obj, struct CO_NODE_T *node, vo
      * Fetch old settings (will be restored in
      * case producer reactivation went wrong
      */
-    (void)uint32->Read(obj, node, &ous, sizeof(ous));
+    (void)uint32->Read(obj, node, &ous, COT_ENTRY_SIZE);
 
-    result = uint32->Write(obj, node, &nus, sizeof(nus));
+    result = uint32->Write(obj, node, &nus, COT_ENTRY_SIZE);
     if (result != CO_ERR_NONE) {
         return CO_ERR_OBJ_RANGE;
     }
@@ -96,7 +96,7 @@ static CO_ERR COTSyncCycleWrite(struct CO_OBJ_T *obj, struct CO_NODE_T *node, vo
              * Object write access was successful once already,
              * no result check is needed.
              */
-            (void)uint32->Write(obj, node, &ous, sizeof(ous));
+            (void)uint32->Write(obj, node, &ous, COT_ENTRY_SIZE);
             sync->Cycle = ous;
             result      = CO_ERR_OBJ_RANGE;
         }

--- a/src/object/cia301/co_sync_id.c
+++ b/src/object/cia301/co_sync_id.c
@@ -71,7 +71,7 @@ static CO_ERR COTSyncIdWrite(struct CO_OBJ_T *obj, struct CO_NODE_T *node, void 
 
     sync = &node->Sync;
     nid = *(uint32_t*)buffer;
-    (void)uint32->Read(obj, node, &oid, sizeof(oid));
+    (void)uint32->Read(obj, node, &oid, COT_ENTRY_SIZE);
 
     /* when current entry is generating SYNCs, bits 0 to 29 shall not be changed */
     if ((oid & CO_SYNC_COBID_ON) != (uint32_t)0) {
@@ -83,7 +83,7 @@ static CO_ERR COTSyncIdWrite(struct CO_OBJ_T *obj, struct CO_NODE_T *node, void 
                 COSyncProdDeactivate(sync);
             }
             sync->CobId = nid;
-            result = uint32->Write(obj, node, &nid, sizeof(nid));
+            result = uint32->Write(obj, node, &nid, COT_ENTRY_SIZE);
             if (result != CO_ERR_NONE) {
                 result = CO_ERR_OBJ_RANGE;
             }
@@ -104,7 +104,7 @@ static CO_ERR COTSyncIdWrite(struct CO_OBJ_T *obj, struct CO_NODE_T *node, void 
             }
         }
         sync->CobId = nid;
-        result = uint32->Write(obj, node, &nid, sizeof(nid));
+        result = uint32->Write(obj, node, &nid, COT_ENTRY_SIZE);
         if (result != CO_ERR_NONE) {
             result = CO_ERR_OBJ_RANGE;
         }


### PR DESCRIPTION
This PR adds changes so that CANopen-stack will run properly on the C28x micro controller.  It adds a typedef to have `uint8_t`s be `uint16_t`s for our specific microcontroller, and it replaces the uses of the `sizeof` operator with macros.