### PR TITLE
    Fixed co_csdo Segmented Download bug

### DIFF
--- a/src/service/cia301/co_csdo.c
+++ b/src/service/cia301/co_csdo.c
@@ -319,7 +319,7 @@ static CO_ERR COCSdoInitDownloadSegmented(CO_CSDO *csdo)
     uint16_t  Idx;
     uint8_t   Sub;
     uint8_t   n;
-    uint8_t   width;
+    uint32_t  width;
     uint8_t   c_bit = 1;
     uint8_t   cmd;
     CO_IF_FRM frm;
@@ -370,7 +370,7 @@ static CO_ERR COCSdoDownloadSegmented(CO_CSDO *csdo)
     uint32_t  ticks;
     uint8_t   cmd;
     uint8_t   n;
-    uint8_t   width;
+    uint32_t  width;
     uint8_t   c_bit = 1;
     CO_IF_FRM frm;
 


### PR DESCRIPTION
    Using a uint8_t for width in the COCSdo Download functions results in a
    premature end to the sdo transfer. On lines 337 and 388 where `width =
    csdo->Tfer.Size - csdo->Tfer.Buf_Idx;` is called, this results in width
    taking the lower 8 bits of the result. This can result in situations
    where the width is <7 even though there are remaining bytes. For
    example, if the size of the file is 1000 and the buffer index is at 231,
    the uint32_t subtraction yields 0x301 which is truncated to 0x01 through
    the uint8_t typecast enforced by setthing this value to `uint8_t width`.

    The fix for this is simply to change the width variable to a uint32_t.
    This allows the full amount of bytes to be transfered. The `if (width
    >7u)` check ensures that a max of 7 bytes are still copied into the
    frame.