### PR TITLE
fixed checked for exact length match on file size for upload

### DIFF
--- a/src/service/cia301/co_csdo.c
+++ b/src/service/cia301/co_csdo.c
@@ -235,10 +235,11 @@ static CO_ERR COCSdoInitUploadSegmented(CO_CSDO *csdo)
     Sub = CO_GET_BYTE(csdo->Frm, 3u);
 
     /* verify size, Idx, Sub */
-    if ((obj_size == csdo->Tfer.Size) &&
+    if ((obj_size <= csdo->Tfer.Size) &&
         (Idx == csdo->Tfer.Idx) &&
         (Sub == csdo->Tfer.Sub)) {
 
+        csdo->Tfer.Size = obj_size;
         result = CO_ERR_NONE;
 
         /* setup CAN request */


### PR DESCRIPTION
For some reason, there is a check for an exact match on file size for CANopen uploads but we do not know the exact file size when requesting uploads. Fixed this by checking for greater than or equal to the buffer size passed in. This works as long as the buffer provided is larger than the file uploaded.

Also, set the Tfer size to the obj_size. This allows us to know the actual file size we received in the callback and can pass this along to rust.