### PR TITLE
Apply MISRA Rule 9.1 for canopen-stack

### DIFF
--- a/src/object/cia301/co_hb_cons.c
+++ b/src/object/cia301/co_hb_cons.c
@@ -262,7 +262,7 @@ int16_t CONmtHbConsCheck(CO_NMT *nmt, CO_IF_FRM *frm)
     int16_t    result = -1;
     uint32_t   cobid;
     uint32_t   ticks;
-    uint8_t    nodeid;
+    uint8_t    nodeid = NULL;
 
     cobid  = frm->Identifier;
     hbc    = nmt->HbCons;


### PR DESCRIPTION
Resolve MISRA rule 9.1 for canopen-stack.